### PR TITLE
Fix crash when initial VST_Path doesn't exist

### DIFF
--- a/midiAuralizer.py
+++ b/midiAuralizer.py
@@ -153,9 +153,10 @@ class Main(QMainWindow):
         self.layout = QGridLayout(self.centralWidget)
         
         self.list_instruments = []
-        for i in os.listdir(VST_PATH):
-            if i[-4:] == '.dll':
-                self.list_instruments.append(i[:-4])
+        if os.path.exists(VST_PATH):
+            for i in os.listdir(VST_PATH):
+                if i[-4:] == '.dll':
+                    self.list_instruments.append(i[:-4])
         
         self.midifiles = []
         self.img_dragMidi = QLabel(self)


### PR DESCRIPTION
The program used to crash if the VST_Path (C:\\VstPlugins) didn't exist, because the __init__ method of the Main class would call os.listdir() on the non existent VST_Path when trying to fill self.instruments with the instrument filenames.

Added a check for the existence of the VST folder before filling list_instruments. Now if the folder doesn't exist, the list is left empty. Empty list situation is already handled in the code, so the program doesn't crash anymore and asks the user to locate the VST folder.

This is a tiny but important change, because program crashing on first run may be a bit confusing and off-putting for new users.